### PR TITLE
fix mandala deploy

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,20 +1,36 @@
 const { ethers, upgrades } = require("hardhat");
 const { txParams } = require("../utils/transactionHelpers.js");
+const { EvmRpcProvider } = require("@acala-network/eth-providers");
+
 
 async function main() {
   const ethParams = await txParams();
 
-  const [deployer] = await ethers.getSigners();
+  /* -------------------------------------------------------------------------------------- */
+  // https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/85#issuecomment-1028435049
 
-  const MyToken = await ethers.getContractFactory("MyToken");
-  const instance = await upgrades.deployProxy(MyToken, {
+  // Wrap the provider so we can override fee data.
+  const provider = EvmRpcProvider.from('ws://localhost:9944');
+  await provider.isReady();
+
+  provider.getFeeData = async () => ({
     gasPrice: ethParams.txGasPrice,
     gasLimit: ethParams.txGasLimit,
   });
 
+  // Create the signer for the mnemonic, connected to the provider with hardcoded fee data
+  const signer = ethers.Wallet.fromMnemonic('fox sight canyon orphan hotel grow hedgehog build bless august weather swarm').connect(provider);
+
+  /* -------------------------------------------------------------------------------------- */
+
+  const MyToken = await ethers.getContractFactory("MyToken", signer);
+  const instance = await upgrades.deployProxy(MyToken);
+
   await instance.deployed();
 
   console.log("MyToken deployed at:", instance.address);
+
+  await provider.disconnect();
 }
 
 main()

--- a/test/MyToken.js
+++ b/test/MyToken.js
@@ -1,6 +1,7 @@
+// const ethers = require("ethers");
 const { ethers, upgrades } = require("hardhat");
 const { expect } = require("chai");
-const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
+const { calcEthereumTransactionParams, calcSubstrateTransactionParams, EvmRpcProvider } = require("@acala-network/eth-providers");
 
 const txFeePerGas = '199999946752';
 const storageByteDeposit = '100000000000000';
@@ -17,15 +18,31 @@ describe("MyToken contract", function () {
             storageByteDeposit
         });
 
-        const MyToken = await ethers.getContractFactory("MyToken");
-        
-        const instance = await upgrades.deployProxy(MyToken, {
+        /* -------------------------------------------------------------------------------------- */
+        // https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/85#issuecomment-1028435049
+
+        // Wrap the provider so we can override fee data.
+        const provider = EvmRpcProvider.from('ws://localhost:9944');
+        await provider.isReady();
+
+        provider.getFeeData = async () => ({
             gasPrice: ethParams.txGasPrice,
             gasLimit: ethParams.txGasLimit,
         });
 
+        // Create the signer for the mnemonic, connected to the provider with hardcoded fee data
+        const signer = ethers.Wallet.fromMnemonic('fox sight canyon orphan hotel grow hedgehog build bless august weather swarm').connect(provider);
+
+        /* -------------------------------------------------------------------------------------- */
+
+        const MyToken = await ethers.getContractFactory("MyToken", signer);
+        
+        const instance = await upgrades.deployProxy(MyToken);
+
         const value = await instance.totalSupply();
 
         expect(ethers.utils.formatEther(value)).to.equal('1000000.0');
+
+        await provider.disconnect();
     });
 });


### PR DESCRIPTION
## Change
previous issue was that 
```
upgrades.deployProxy(Token, gasParams)
```
is not the expected interface.

`deployProxy` doesn't support custom gas directly, so we have to use some workaround to do it. https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/85#issuecomment-1028435049

`ws://localhost:9944` is the local mandala node url.

This is a *working* version, further polish can be done [like this](https://github.com/shunjizhan/acala-test-yanda/pull/1)

## Test
start a node and rpc adapter locally 
```
docker run -it --rm -p 9944:9944 -p 9933:9933 ghcr.io/acalanetwork/mandala-node:sha-189103e --dev --ws-external --rpc-port=9933 --rpc-external --rpc-cors=all --rpc-methods=unsafe --tmp -levmebug
```
```
LOCAL_MODE=1 npx @acala-network/eth-rpc-adapter
```

both these two commands worked:
- `yarn hardhat run scripts/deploy.js --network mandala` 
- `yarn test --network mandala`
sometimes got `InvalidDeployment [Error]: No contract at address xxx (Removed from manifest)` for the above tests, not sure what this is, rerun works